### PR TITLE
531: Configure ingress to verify client certificate is issued by one of the configured CAs (if a client cert is present)

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
-    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional
     nginx.ingress.kubernetes.io/http2-max-field-size: 16k
     nginx.ingress.kubernetes.io/http2-max-header-size: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m


### PR DESCRIPTION
Configure ingress to verify client certificate is issued by one of the configured CAs (if a client cert is present)

The previous configuration of optional_no_ca would not check if the certificate was issued by one of the configured CAs.

Certificate checking cannot be mandatory (config value of: "on"), as there are certain routes where a client certificate is not required. The nginx config applies to all access via this ingress, so must be a flavour of optional. Checking that a client cert was presented, and is valid will need to be done in our IG routes, by checking the ssl-client-verify header.

https://github.com/SecureApiGateway/SecureApiGateway/issues/531