### PR TITLE
764: Adding an init container to the IG deployment to setup the truststore

### DIFF
--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -14,6 +14,30 @@ spec:
       labels:
         app: ig
     spec:
+      initContainers:
+        # Copies certs from the ig-truststore-pem into the new-truststore volume
+        - name: truststore-init
+          image: ig
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: new-truststore
+              mountPath: /truststore
+            - name: ig-truststore-pem
+              mountPath: /var/run/secrets/truststore
+          command: [ "/home/forgerock/import-pem-certs.sh" ]
+          env:
+            - name: TRUSTSTORE_PATH
+              value: /truststore/igtruststore
+            - name: TRUSTSTORE_PASSWORD
+              value: changeit
+            - name: TRUSTSTORE_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: securebanking-platform-config
+                  key: IG_TRUSTSTORE_PASSWORD
+            - name: IG_PEM_TRUSTSTORE
+              value: "/var/run/secrets/truststore/ig-truststore.pem"
+
       containers:
       - name: ig
         env:
@@ -37,6 +61,11 @@ spec:
         #image: gcr.io/forgerock-io/ig/docker-build:7.0.0-af5592b
         image: ig
         imagePullPolicy: Always
+        volumeMounts:
+          - name: new-truststore
+            mountPath: /var/ig/secrets/igtruststore
+            readOnly: true
+            subPath: igtruststore
         livenessProbe:
           httpGet:
             path: /kube/liveness
@@ -54,3 +83,11 @@ spec:
           requests:
             cpu: 200m
             memory: 512Mi
+      volumes:
+        # Empty volume where the igtruststore will be created by the initContainer, it can then be mounted into the ig container
+        - name: new-truststore
+          emptyDir: { }
+        - name: ig-truststore-pem
+          secret:
+            secretName: ig-truststore-pem
+            optional: false

--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -26,6 +26,7 @@ spec:
               mountPath: /var/run/secrets/truststore
           command: [ "/home/forgerock/import-pem-certs.sh" ]
           env:
+            # Path of the new truststore to create
             - name: TRUSTSTORE_PATH
               value: /truststore/igtruststore
             - name: TRUSTSTORE_PASSWORD
@@ -33,6 +34,7 @@ spec:
                 configMapKeyRef:
                   name: securebanking-platform-config
                   key: IG_TRUSTSTORE_PASSWORD
+            # Path to the pem file containing the certs to copy into the new truststore
             - name: IG_PEM_TRUSTSTORE
               value: "/var/run/secrets/truststore/ig-truststore.pem"
 

--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -29,8 +29,6 @@ spec:
             - name: TRUSTSTORE_PATH
               value: /truststore/igtruststore
             - name: TRUSTSTORE_PASSWORD
-              value: changeit
-            - name: TRUSTSTORE_PASSWORD
               valueFrom:
                 configMapKeyRef:
                   name: securebanking-platform-config

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -23,7 +23,7 @@ data:
   IG_AGENT_PASSWORD: password
   IG_RCS_SECRET: password
   IG_SSA_SECRET: password
-  IG_TRUSTSTORE_PASSWORD: Passw0rd
+  IG_TRUSTSTORE_PASSWORD: changeit
   CERT_ISSUER: null-issuer
   ASPSP_KEYSTORE_PATH: /secrets/aspsp.test.p12
   ASPSP_KEYSTORE_PASSWORD: password

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -23,6 +23,7 @@ data:
   IG_AGENT_PASSWORD: password
   IG_RCS_SECRET: password
   IG_SSA_SECRET: password
+  IG_TRUSTSTORE_PASSWORD: Passw0rd
   CERT_ISSUER: null-issuer
   ASPSP_KEYSTORE_PATH: /secrets/aspsp.test.p12
   ASPSP_KEYSTORE_PASSWORD: password


### PR DESCRIPTION
Utilising the import-pem-certs.sh in the IG image to add a PEM to the ig truststore. 
This script is run by an InitContainer, the truststore is created in a volume which is mounted by the ig container.

Adding a configmap item for the truststore password.

https://github.com/SecureApiGateway/SecureApiGateway/issues/764