### PR TITLE
764: Mount IG secrets

### DIFF
--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         imagePullPolicy: Always
         volumeMounts:
           - name: new-truststore
-            mountPath: /var/ig/secrets
+            mountPath: /var/ig/secrets/truststore
             readOnly: true
           - name: ig-ob-signing-key
             mountPath: /var/ig/secrets/open-banking

--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -63,13 +63,11 @@ spec:
         imagePullPolicy: Always
         volumeMounts:
           - name: new-truststore
-            mountPath: /var/ig/secrets/igtruststore
+            mountPath: /var/ig/secrets
             readOnly: true
-            subPath: igtruststore
           - name: ig-ob-signing-key
-            mountPath: /var/ig/secrets/ig-ob-signing-key.p12
+            mountPath: /var/ig/secrets/open-banking
             readOnly: true
-            subPath: ig-ob-signing-key.p12
           - name: test-trusted-dir-keys
             mountPath: /var/ig/secrets/test-trusted-directory
             readOnly: true

--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -70,6 +70,9 @@ spec:
             mountPath: /var/ig/secrets/ig-ob-signing-key.p12
             readOnly: true
             subPath: ig-ob-signing-key.p12
+          - name: test-trusted-dir-keys
+            mountPath: /var/ig/secrets/test-trusted-directory
+            readOnly: true
         livenessProbe:
           httpGet:
             path: /kube/liveness
@@ -98,4 +101,8 @@ spec:
         - name: ig-ob-signing-key
           secret:
             secretName: ig-ob-signing-key
+            optional: false
+        - name: test-trusted-dir-keys
+          secret:
+            secretName: test-trusted-dir-keys
             optional: false

--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -66,6 +66,10 @@ spec:
             mountPath: /var/ig/secrets/igtruststore
             readOnly: true
             subPath: igtruststore
+          - name: ig-ob-signing-key
+            mountPath: /var/ig/secrets/ig-ob-signing-key.p12
+            readOnly: true
+            subPath: ig-ob-signing-key.p12
         livenessProbe:
           httpGet:
             path: /kube/liveness
@@ -90,4 +94,8 @@ spec:
         - name: ig-truststore-pem
           secret:
             secretName: ig-truststore-pem
+            optional: false
+        - name: ig-ob-signing-key
+          secret:
+            secretName: ig-ob-signing-key
             optional: false

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -25,13 +25,14 @@ data:
   IG_SSA_SECRET: password
   IG_TRUSTSTORE_PASSWORD: changeit
   CERT_ISSUER: null-issuer
-  ASPSP_KEYSTORE_PATH: /secrets/aspsp.test.p12
+  ASPSP_KEYSTORE_PATH: /secrets/ig-ob-signing-key.p12
   ASPSP_KEYSTORE_PASSWORD: password
   ASPSP_JWTSIGNER_ALIAS: jwtsigner
   ASPSP_JWTSIGNER_KID: NTOZs+cHZSyO0p0AKPuHctl2ddc=
-  CA_KEYSTORE_PATH: /secrets/ca.p12
+  CA_KEYSTORE_PATH: /secrets/test-trusted-directory/ca.p12
   CA_KEYSTORE_TYPE: PKCS12
   CA_KEYSTORE_STOREPASS: Passw0rd
   CA_KEYSTORE_KEYPASS: Passw0rd
   CA_KEYSTORE_ALIAS: ca
   CA_KEK: Syz1K5XQCZtq7FkE+GNvgZPeFyvUXJdemIW7CQjM18U=
+  TEST_DIRECTORY_SIGNING_KEY_PATH: /secrets/test-trusted-directory/

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -25,7 +25,7 @@ data:
   IG_SSA_SECRET: password
   IG_TRUSTSTORE_PASSWORD: changeit
   CERT_ISSUER: null-issuer
-  ASPSP_KEYSTORE_PATH: /secrets/ig-ob-signing-key.p12
+  ASPSP_KEYSTORE_PATH: /secrets/open-banking/ig-ob-signing-key.p12
   ASPSP_KEYSTORE_PASSWORD: password
   ASPSP_JWTSIGNER_ALIAS: jwtsigner
   ASPSP_JWTSIGNER_KID: NTOZs+cHZSyO0p0AKPuHctl2ddc=

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -35,4 +35,4 @@ data:
   CA_KEYSTORE_KEYPASS: Passw0rd
   CA_KEYSTORE_ALIAS: ca
   CA_KEK: Syz1K5XQCZtq7FkE+GNvgZPeFyvUXJdemIW7CQjM18U=
-  TEST_DIRECTORY_SIGNING_KEY_PATH: /secrets/test-trusted-directory/
+  TEST_DIRECTORY_SIGNING_KEY_PATH: /secrets/test-trusted-directory/test-trusted-directory-signing-key.p12

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -24,6 +24,7 @@ data:
   IG_RCS_SECRET: password
   IG_SSA_SECRET: password
   IG_TRUSTSTORE_PASSWORD: changeit
+  IG_TRUSTSTORE_PATH: /secrets/truststore/igtruststore
   CERT_ISSUER: null-issuer
   ASPSP_KEYSTORE_PATH: /secrets/open-banking/ig-ob-signing-key.p12
   ASPSP_KEYSTORE_PASSWORD: password


### PR DESCRIPTION
In https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/pull/9 we mounted the IG truststore secret, in this change we are mounting the remaining secrets into the IG container.

The secrets directory structure has been changed (compared to what was built by the docker image), to add sub folders groups secrets by use:
- open-banking
- test-trusted-directory
- truststore

This provides a cleaner structure and allow us to remove the use of subPath when mounting the secret volume (secrets mounted in such a fashion are not automatically updated in the container when the referenced k8s secret object is updated).


Secrets being mounted:

- ig-ob-signing-key (Open Banking private signing key aka OBSeal)
- Test Trusted Directory Secrets
  - ca.p12 (the cert used to sign certificates issued by the Test Trusted Directory)
  - test directory SSA signing key


https://github.com/SecureApiGateway/SecureApiGateway/issues/764