### PR TITLE
764: Removing unused configuration items from configmap

### DIFF
--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -35,5 +35,4 @@ data:
   CA_KEYSTORE_STOREPASS: Passw0rd
   CA_KEYSTORE_KEYPASS: Passw0rd
   CA_KEYSTORE_ALIAS: ca
-  CA_KEK: Syz1K5XQCZtq7FkE+GNvgZPeFyvUXJdemIW7CQjM18U=
   TEST_DIRECTORY_SIGNING_KEY_PATH: /secrets/test-trusted-directory/test-trusted-directory-signing-key.p12

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -22,7 +22,6 @@ data:
   IG_AGENT_ID: ig-agent
   IG_AGENT_PASSWORD: password
   IG_RCS_SECRET: password
-  IG_SSA_SECRET: password
   IG_TRUSTSTORE_PASSWORD: changeit
   IG_TRUSTSTORE_PATH: /secrets/truststore/igtruststore
   CERT_ISSUER: null-issuer


### PR DESCRIPTION
Removing unused CA_KEK and IG_SSA_SECRET config items.
Related IG PR: https://github.com/SecureApiGateway/securebanking-openbanking-uk-gateway/pull/285

https://github.com/SecureApiGateway/SecureApiGateway/issues/764