### PR TITLE
765: Using a single keystore secret for both Test Trusted Directory keystores

### DIFF
--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           - name: ig-ob-signing-key
             mountPath: /var/ig/secrets/open-banking
             readOnly: true
-          - name: test-trusted-dir-keys
+          - name: test-trusted-dir-keystore
             mountPath: /var/ig/secrets/test-trusted-directory
             readOnly: true
         livenessProbe:
@@ -100,7 +100,7 @@ spec:
           secret:
             secretName: ig-ob-signing-key
             optional: false
-        - name: test-trusted-dir-keys
+        - name: test-trusted-dir-keystore
           secret:
-            secretName: test-trusted-dir-keys
+            secretName: test-trusted-dir-keystore
             optional: false

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -27,9 +27,9 @@ data:
   IG_OB_ASPSP_KEYSTORE_PATH: /secrets/open-banking/ig-ob-signing-key.p12
   IG_OB_ASPSP_JWTSIGNER_ALIAS: jwtsigner
   IG_OB_ASPSP_JWTSIGNER_KID: NTOZs+cHZSyO0p0AKPuHctl2ddc=
-  IG_TEST_DIRECTORY_CA_KEYSTORE_PATH: /secrets/test-trusted-directory/ca.p12
+  IG_TEST_DIRECTORY_CA_KEYSTORE_PATH: /secrets/test-trusted-directory/test-trusted-dir-keystore.p12
   IG_TEST_DIRECTORY_CA_KEYSTORE_TYPE: PKCS12
   IG_TEST_DIRECTORY_CA_KEYSTORE_ALIAS: ca
-  IG_TEST_DIRECTORY_SIGNING_KEYSTORE_PATH: /secrets/test-trusted-directory/test-trusted-directory-signing-key.p12
+  IG_TEST_DIRECTORY_SIGNING_KEYSTORE_PATH: /secrets/test-trusted-directory/test-trusted-dir-keystore.p12
   IG_TEST_DIRECTORY_SIGNING_KEYSTORE_TYPE: PKCS12
   IG_TEST_DIRECTORY_SIGNING_KEYSTORE_ALIAS: jwt-signer


### PR DESCRIPTION
A single keystore will contain both keys for use by the Test Trusted Dir.

Related PR: https://github.com/SecureApiGateway/sbat-cd/pull/92

https://github.com/SecureApiGateway/SecureApiGateway/issues/765