### PR TITLE
783: Removing unused IG_RCS_SECRET configmap key

### DIFF
--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -22,7 +22,6 @@ data:
   IG_IDM_PASSWORD: 0penBanking!
   IG_AGENT_ID: ig-agent
   IG_AGENT_PASSWORD: password
-  IG_RCS_SECRET: password
   IG_TRUSTSTORE_PATH: /secrets/truststore/igtruststore
   IG_OB_ASPSP_SIGNING_KEYSTORE_PATH: /secrets/open-banking/ig-ob-signing-key.p12
   IG_OB_ASPSP_SIGNING_KEYSTORE_TYPE: PKCS12


### PR DESCRIPTION
This environment variable is not used by IG anymore.

https://github.com/SecureApiGateway/SecureApiGateway/issues/783