### PR TITLE
779: Adding RCS Consent Response JWT config to platform configmap

### DIFF
--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -13,6 +13,8 @@ data:
   RS_FQDN: rs.dev.forgerock.financial
   RCS_FQDN: rcs.dev.forgerock.financial
   RCS_UI_FQDN: rcs-ui.dev.forgerock.financial
+  RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID: rcs-jwt-signer
+  RCS_CONSENT_RESPONSE_JWT_ISSUER: secure-open-banking-rcs
   AM_REALM: alpha
   USER_OBJECT: user
   CERT_ISSUER: null-issuer


### PR DESCRIPTION
Values are required by the initializer and rcs:
- RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID : kid for signing key in JWKSet and signed JWT header
- RCS_CONSENT_RESPONSE_JWT_ISSUER : RCS issuer, must match AM Remote Config configuration ID and signed JWT iss claim

https://github.com/SecureApiGateway/SecureApiGateway/issues/779