### PR TITLE
793: Adding ingress rule /rcs/ui to route to IG

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -41,13 +41,6 @@ spec:
             name: ig
             port:
               number: 8080
-        path: /rcs
-        pathType: Exact
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
         path: /rcs/
         pathType: Prefix
       - backend:

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -45,7 +45,7 @@ spec:
         pathType: Exact
       - backend:
           service:
-            name: securebanking-ui-rcs-ui
+            name: ig
             port:
               number: 8080
         path: /rcs/

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -41,7 +41,7 @@ spec:
             name: ig
             port:
               number: 8080
-        path: /rcs/
+        path: /rcs/ui/
         pathType: Prefix
       - backend:
           service:

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -35,7 +35,14 @@ spec:
             port:
               number: 8080
         path: /rcs-api
-        pathType: Exact        
+        pathType: Exact
+      - backend:
+          service:
+            name: ig
+            port:
+              number: 8080
+        path: /rcs
+        pathType: Exact
       - backend:
           service:
             name: ig

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -45,6 +45,13 @@ spec:
         pathType: Exact
       - backend:
           service:
+            name: securebanking-ui-rcs-ui
+            port:
+              number: 8080
+        path: /rcs/
+        pathType: Prefix
+      - backend:
+          service:
             name: ig
             port:
               number: 8080

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -12,7 +12,7 @@ data:
   ENVIRONMENT_TYPE: CDK
   RS_FQDN: rs.dev.forgerock.financial
   RCS_FQDN: rcs.dev.forgerock.financial
-  RCS_UI_FQDN: rcs-ui.dev.forgerock.financial
+  RCS_UI_INTERNAL_SVC: securebanking-ui-rcs-ui
   RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID: rcs-jwt-signer
   RCS_CONSENT_RESPONSE_JWT_ISSUER: secure-open-banking-rcs
   AM_REALM: alpha


### PR DESCRIPTION
Route traffic for RCS-UI via IG.
See related Gateway PR: https://github.com/SecureApiGateway/securebanking-openbanking-uk-gateway/pull/301

Removing RCS_UI_FQDN and replacing it with RCS_UI_INTERNAL_SVC configmap key. This is the internal address of the RCS UI to be called from the IG pod.

https://github.com/SecureApiGateway/SecureApiGateway/issues/793