### PR TITLE
805: Configuring /rcs/api/ ingress rule for rcs

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -34,8 +34,8 @@ spec:
             name: ig
             port:
               number: 8080
-        path: /rcs-api
-        pathType: Exact
+        path: /rcs/api/
+        pathType: Prefix
       - backend:
           service:
             name: ig

--- a/kustomize/overlay/7.1.0/securebanking/bohocode/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/bohocode/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: bohocode.forgerock.financial
   IG_FQDN: obdemo.bohocode.forgerock.financial
   RS_FQDN: rs.bohocode.forgerock.financial
-  RCS_FQDN: rcs.bohocode.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.bohocode.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/christian-brindley/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/christian-brindley/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: christian-brindley.forgerock.financial
   IG_FQDN: obdemo.christian-brindley.forgerock.financial
   RS_FQDN: rs.christian-brindley.forgerock.financial
-  RCS_FQDN: rcs.christian-brindley.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.christian-brindley.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/dbadham-fr/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/dbadham-fr/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: dbadham-fr.forgerock.financial
   IG_FQDN: obdemo.dbadham-fr.forgerock.financial
   RS_FQDN: rs.dbadham-fr.forgerock.financial
-  RCS_FQDN: rcs.dbadham-fr.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.dbadham-fr.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -11,7 +11,7 @@ data:
   # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
   ENVIRONMENT_TYPE: CDK
   RS_FQDN: rs.dev.forgerock.financial
-  RCS_FQDN: rcs.dev.forgerock.financial
+  RCS_API_INTERNAL_SVC: securebanking-openbanking-uk-rcs
   RCS_UI_INTERNAL_SVC: securebanking-ui-rcs-ui
   RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID: rcs-jwt-signer
   RCS_CONSENT_RESPONSE_JWT_ISSUER: secure-open-banking-rcs

--- a/kustomize/overlay/7.1.0/securebanking/dev/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/dev/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: dev.forgerock.financial
   IG_FQDN: obdemo.dev.forgerock.financial
   RS_FQDN: rs.dev.forgerock.financial
-  RCS_FQDN: rcs.dev.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/devops/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/devops/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: devops.forgerock.financial
   IG_FQDN: obdemo.devops.forgerock.financial
   RS_FQDN: rs.devops.forgerock.financial
-  RCS_FQDN: rcs.devops.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.devops.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/frlaura-jianu/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/frlaura-jianu/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: frlaura-jianu.forgerock.financial
   IG_FQDN: obdemo.frlaura-jianu.forgerock.financial
   RS_FQDN: rs.frlaura-jianu.forgerock.financial
-  RCS_FQDN: rcs.frlaura-jianu.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.frlaura-jianu.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/jorgesanchezperez/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/jorgesanchezperez/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: jorgesanchezperez.forgerock.financial
   IG_FQDN: obdemo.jorgesanchezperez.forgerock.financial
   RS_FQDN: rs.jorgesanchezperez.forgerock.financial
-  RCS_FQDN: rcs.jorgesanchezperez.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.jorgesanchezperez.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/mariantiris/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/mariantiris/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: mariantiris.forgerock.financial
   IG_FQDN: obdemo.mariantiris.forgerock.financial
   RS_FQDN: rs.mariantiris.forgerock.financial
-  RCS_FQDN: rcs.mariantiris.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.mariantiris.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/nightly/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/nightly/configmap.yaml
@@ -7,7 +7,6 @@ data:
   BASE_FQDN: nightly.forgerock.financial
   IG_FQDN: obdemo.nightly.forgerock.financial
   RS_FQDN: rs.nightly.forgerock.financial
-  RCS_FQDN: rcs.nightly.forgerock.financial
   IDENTITY_PLATFORM_FQDN: openam-forgerock-securebankingaccelerato.forgeblocks.com
   USER_OBJECT: alpha_user
   IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE: PasswordGrant

--- a/kustomize/overlay/7.1.0/securebanking/shaunharrisonfr/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/shaunharrisonfr/configmap.yaml
@@ -6,5 +6,4 @@ data:
   BASE_FQDN: shaunharrisonfr.forgerock.financial
   IG_FQDN: obdemo.shaunharrisonfr.forgerock.financial
   RS_FQDN: rs.shaunharrisonfr.forgerock.financial
-  RCS_FQDN: rcs.shaunharrisonfr.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.shaunharrisonfr.forgerock.financial


### PR DESCRIPTION
Removing RCS_FQDN config key, replacing it with RCS_API_INTERNAL_SVC which will be used by IG to route internal traffic to RCS API. All external traffic must go via the IG ingress.

https://github.com/SecureApiGateway/SecureApiGateway/issues/805