### PR TITLE
797: Removing RS_FQDN

### DIFF
--- a/kustomize/overlay/7.1.0/securebanking/bohocode/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/bohocode/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: bohocode.forgerock.financial
   IG_FQDN: obdemo.bohocode.forgerock.financial
-  RS_FQDN: rs.bohocode.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.bohocode.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/christian-brindley/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/christian-brindley/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: christian-brindley.forgerock.financial
   IG_FQDN: obdemo.christian-brindley.forgerock.financial
-  RS_FQDN: rs.christian-brindley.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.christian-brindley.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/dbadham-fr/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/dbadham-fr/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: dbadham-fr.forgerock.financial
   IG_FQDN: obdemo.dbadham-fr.forgerock.financial
-  RS_FQDN: rs.dbadham-fr.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.dbadham-fr.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -10,7 +10,6 @@ data:
   # CDM value: CDM (Cloud Deployment Model)
   # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
   ENVIRONMENT_TYPE: CDK
-  RS_FQDN: rs.dev.forgerock.financial
   RS_INTERNAL_SVC: securebanking-openbanking-uk-rs
   RCS_API_INTERNAL_SVC: securebanking-openbanking-uk-rcs
   RCS_UI_INTERNAL_SVC: securebanking-ui-rcs-ui

--- a/kustomize/overlay/7.1.0/securebanking/dev/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/dev/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: dev.forgerock.financial
   IG_FQDN: obdemo.dev.forgerock.financial
-  RS_FQDN: rs.dev.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/devops/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/devops/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: devops.forgerock.financial
   IG_FQDN: obdemo.devops.forgerock.financial
-  RS_FQDN: rs.devops.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.devops.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/frlaura-jianu/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/frlaura-jianu/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: frlaura-jianu.forgerock.financial
   IG_FQDN: obdemo.frlaura-jianu.forgerock.financial
-  RS_FQDN: rs.frlaura-jianu.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.frlaura-jianu.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/jorgesanchezperez/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/jorgesanchezperez/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: jorgesanchezperez.forgerock.financial
   IG_FQDN: obdemo.jorgesanchezperez.forgerock.financial
-  RS_FQDN: rs.jorgesanchezperez.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.jorgesanchezperez.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/mariantiris/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/mariantiris/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: mariantiris.forgerock.financial
   IG_FQDN: obdemo.mariantiris.forgerock.financial
-  RS_FQDN: rs.mariantiris.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.mariantiris.forgerock.financial

--- a/kustomize/overlay/7.1.0/securebanking/nightly/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/nightly/configmap.yaml
@@ -6,7 +6,6 @@ data:
   ENVIRONMENT_TYPE: FIDC
   BASE_FQDN: nightly.forgerock.financial
   IG_FQDN: obdemo.nightly.forgerock.financial
-  RS_FQDN: rs.nightly.forgerock.financial
   IDENTITY_PLATFORM_FQDN: openam-forgerock-securebankingaccelerato.forgeblocks.com
   USER_OBJECT: alpha_user
   IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE: PasswordGrant

--- a/kustomize/overlay/7.1.0/securebanking/shaunharrisonfr/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/shaunharrisonfr/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
 data:
   BASE_FQDN: shaunharrisonfr.forgerock.financial
   IG_FQDN: obdemo.shaunharrisonfr.forgerock.financial
-  RS_FQDN: rs.shaunharrisonfr.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.shaunharrisonfr.forgerock.financial


### PR DESCRIPTION
This config is now longer used, the ingress that was bound to this host is no longer created.

See related PR: https://github.com/SecureApiGateway/securebanking-openbanking-uk-rs/pull/130

https://github.com/SecureApiGateway/SecureApiGateway/issues/797