### PR TITLE
797: Adding RS_FQDN value back in

### DIFF
--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -10,6 +10,7 @@ data:
   # CDM value: CDM (Cloud Deployment Model)
   # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
   ENVIRONMENT_TYPE: CDK
+  RS_FQDN: localhost # temp fudge to get environment working, until swagger is fixed to not need this value
   RS_INTERNAL_SVC: securebanking-openbanking-uk-rs
   RCS_API_INTERNAL_SVC: securebanking-openbanking-uk-rcs
   RCS_UI_INTERNAL_SVC: securebanking-ui-rcs-ui


### PR DESCRIPTION
The value is a dummy value to get the swagger deployed. Swagger will not be functional.

https://github.com/SecureApiGateway/SecureApiGateway/issues/797