### PR TITLE
293: Removing /repo ingress rule

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -49,15 +49,7 @@ spec:
             port:
               number: 8080
         path: /rs
-        pathType: Exact        
-# Temporary - this will be internal
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /repo
-        pathType: Exact        
+        pathType: Exact
 # Temporary - this will be internal
       - backend:
           service:

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -49,7 +49,15 @@ spec:
             port:
               number: 8080
         path: /rs
-        pathType: Exact
+        pathType: Exact        
+# Temporary - this will be internal
+      - backend:
+          service:
+            name: ig
+            port:
+              number: 8080
+        path: /repo
+        pathType: Exact        
 # Temporary - this will be internal
       - backend:
           service:

--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -19,6 +19,7 @@ data:
   AM_REALM: alpha
   USER_OBJECT: user
   CERT_ISSUER: null-issuer
+  IG_INTERNAL_SVC: ig
   IG_CLIENT_ID: ig-client
   IG_CLIENT_SECRET: password
   IG_IDM_USER: service_account.ig


### PR DESCRIPTION
/repo is an internal only feature. Removing the ingress rule so that it can only be accessed internally.

Adding IG_INTERNAL_SVC is the internal k8s svc address for IG. This can be used by pods within the cluster to talk to IG.

https://github.com/SecureApiGateway/SecureApiGateway/issues/239