### PR TITLE
782: Creating an open-banking ingress

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -128,6 +128,6 @@ spec:
               service:
                 name: ig
                 port:
-                  number: 8080
+                  number: 80
             path: /ig(/|$)(.*)
             pathType: Exact

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -4,9 +4,6 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
-    nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
-    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
     nginx.ingress.kubernetes.io/http2-max-field-size: 16k
     nginx.ingress.kubernetes.io/http2-max-header-size: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -1,5 +1,4 @@
-# When K8S is upgraded to >= 1.14 - change the apiVersion to:
-#apiVersion: networking.k8s.io/v1beta1
+# Ingress for access to ForgeRock services, protected by a non Open Banking cert e.g. Let's Encrypt
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -19,57 +18,94 @@ metadata:
   name: forgerock
 spec:
   rules:
-  - host: $(IG_FQDN)
-    http:
-      paths:
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /am
-        pathType: Exact
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /rcs/api/
-        pathType: Prefix
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /rcs/ui/
-        pathType: Prefix
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /rs
-        pathType: Exact
-# Temporary - this will be internal
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /jwkms
-        pathType: Exact        
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /jwksproxy
-        pathType: Exact        
+    - host: $(IG_FQDN)
+      http:
+        paths:
+          # Access to the AM XUI, this is used when the PSU (end user) logs in via the browser
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/XUI
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rcs/api/
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rcs/ui/
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /jwkms
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /jwksproxy
+            pathType: Prefix
   tls:
-  - hosts:
-    - $(IG_FQDN)
-    secretName: sslcert
+    - hosts:
+        - $(IG_FQDN)
+      secretName: sslcert
+
 ---
+# Ingress for access to Open Banking APIs, this is protected by an Open Banking Directory OBWac cert
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
+    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: open-banking
+spec:
+  rules:
+    - host: $(IG_FQDN)
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rs
+            pathType: Prefix
+  tls:
+    - hosts:
+        - $(IG_FQDN)
+      secretName: sslcert # TODO Use an Open Banking OBWac
+---
+# Access to the IG Studio UI, this should only be available in Development environments
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -81,17 +117,17 @@ metadata:
 
 spec:
   tls:
-  - hosts:
-    - $(IG_FQDN)
-    secretName: sslcert
+    - hosts:
+        - $(IG_FQDN)
+      secretName: sslcert
   rules:
-  - host: $(IG_FQDN)
-    http:
-      paths:
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /ig(/|$)(.*)
-        pathType: Exact
+    - host: $(IG_FQDN)
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 8080
+            path: /ig(/|$)(.*)
+            pathType: Exact


### PR DESCRIPTION
Adding an open-banking ingress definition which contains rules that need to be protected by an Open Banking Directory issued OBWac cert.

Added a new rule to the forgerock ingress: /am/XUI. This is called when AM is simulating an ASPSP (Bank) login portal, which will use a Bank's regular TLS cert (non Open banking).

Currently, this change is just structural. The open-banking ingress is using the same cert as the other ingresses until we have a valid OBWac for our environment.

forgerock ingress includes the following:
- /am/XUI
  - New route which sits at the start of the PSU consent authorisation flow
  - Used when the PSU is redirected to the AM login screen
  - This login screen is simulating the Bank's login portal
- /rcs/ui
  - PSU browser calls to the UI
  - Would be hosted by a Bank
- /rcs/api
  - As above except these are the backend API calls made from the PSU browser
- /jwkms
  - Access to IG routes which implement the Test Trusted Directory
- /jwksproxy
  - Access to IG routes which proxy the Open Banking Directory JWKS endpoints
  - Called by AM and other IG routes when they need to access this OB resource
    - Needed as this allows us to configure client TLS settings to trust the OB CA, not clear how we would do this in AM

open-banking ingress includes the following:
- /rs
  - Calls to IG routes which access RS
- /am
  - Calls to IG routes which access AM
    - DCR / authorize endpoint / access_token endpoint
    - Note: this overlaps with /am/XUI defined in the forgerock ingress, according to the nginx docs it will choose the most specific path prefix rule first. So /am/XUI calls will hit the other rule and not this one
      - Easy to test once the OBWac is in place as we can check which cert is being served

https://github.com/SecureApiGateway/SecureApiGateway/issues/782