### PR TITLE
828: Creating mtls ingress

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -1,5 +1,4 @@
-# When K8S is upgraded to >= 1.14 - change the apiVersion to:
-#apiVersion: networking.k8s.io/v1beta1
+# Ingress for routes requiring MTLS with Open Banking Directory issued certs
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -16,60 +15,99 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
     nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
     nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: mtls
+spec:
+  rules:
+    - host: $(IG_FQDN)
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/oauth2/realms/root/realms/$(AM_REALM)/access_token
+            pathType: Exact
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/oauth2/realms/root/realms/$(AM_REALM)/register
+            pathType: Exact
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rs/
+            pathType: Prefix
+  tls:
+    - hosts:
+        - $(IG_FQDN) # TODO use mtls. domain
+      secretName: sslcert # TODO Use OBWac
+---
+# Ingress for access to routes protected with TLS by a ForgeRock cert
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
   name: forgerock
 spec:
   rules:
-  - host: $(IG_FQDN)
-    http:
-      paths:
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /am
-        pathType: Exact
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /rcs/api/
-        pathType: Prefix
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /rcs/ui/
-        pathType: Prefix
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /rs
-        pathType: Exact
-# Temporary - this will be internal
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /jwkms
-        pathType: Exact        
-      - backend:
-          service:
-            name: ig
-            port:
-              number: 8080
-        path: /jwksproxy
-        pathType: Exact        
+    - host: $(IG_FQDN)
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rcs/api/
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rcs/ui/
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /jwkms
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /jwksproxy
+            pathType: Prefix
   tls:
-  - hosts:
-    - $(IG_FQDN)
-    secretName: sslcert
+    - hosts:
+        - $(IG_FQDN)
+      secretName: sslcert
 ---
+# Ingress for dev only, provides access to the IG Studio UI
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -92,6 +130,6 @@ spec:
           service:
             name: ig
             port:
-              number: 8080
+              number: 80
         path: /ig(/|$)(.*)
         pathType: Exact


### PR DESCRIPTION
The mtls ingress contains rules for paths which need protecting with an Open Banking Directory issued cert and must enforce MTLS.

https://github.com/SecureApiGateway/SecureApiGateway/issues/828