### PR TITLE
828: Fixing mtls AM register path to be a Prefix pathType

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -34,7 +34,7 @@ spec:
                 port:
                   number: 80
             path: /am/oauth2/realms/root/realms/alpha/register
-            pathType: Exact
+            pathType: Prefix
           - backend:
               service:
                 name: ig


### PR DESCRIPTION
The register endpoint is used for DCR. 

DCR supports POST/PUT/GET/DELETE. 
- For POST (creating a new registration), the path is an exact match.
- For PUT/GET/DELETE the path is a prefix, with the clientId as a suffix.

https://github.com/SecureApiGateway/SecureApiGateway/issues/828