### PR TITLE
828: Adding test-trusted-directory ingress definition

### DIFF
--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -42,13 +42,6 @@ spec:
                   number: 80
             path: /rs/
             pathType: Prefix
-          - backend:
-              service:
-                name: ig
-                port:
-                  number: 80
-            path: /jwkms
-            pathType: Prefix
   tls:
     - hosts:
         - $(MTLS_FQDN)
@@ -100,14 +93,42 @@ spec:
                 name: ig
                 port:
                   number: 80
-            path: /jwkms/testdirectory/jwks
-            pathType: Exact
+            path: /jwksproxy
+            pathType: Prefix
+  tls:
+    - hosts:
+        - $(IG_FQDN)
+      secretName: sslcert
+---
+# Ingress for the Test Trusted Directory hosted by the gateway.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
+    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: test-trusted-directory
+spec:
+  rules:
+    - host: $(IG_FQDN)
+      http:
+        paths:
           - backend:
               service:
                 name: ig
                 port:
                   number: 80
-            path: /jwksproxy
+            path: /jwkms
             pathType: Prefix
   tls:
     - hosts:

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -42,6 +42,13 @@ spec:
                   number: 80
             path: /rs/
             pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /jwkms
+            pathType: Prefix
   tls:
     - hosts:
         - $(MTLS_FQDN)
@@ -87,13 +94,6 @@ spec:
                 port:
                   number: 80
             path: /rcs/ui/
-            pathType: Prefix
-          - backend:
-              service:
-                name: ig
-                port:
-                  number: 80
-            path: /jwkms
             pathType: Prefix
           - backend:
               service:

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -100,6 +100,13 @@ spec:
                 name: ig
                 port:
                   number: 80
+            path: /jwkms/testdirectory/jwks
+            pathType: Exact
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
             path: /jwksproxy
             pathType: Prefix
   tls:

--- a/kustomize/base/7.1.0/ingress/ingress.yaml
+++ b/kustomize/base/7.1.0/ingress/ingress.yaml
@@ -128,7 +128,7 @@ spec:
                 name: ig
                 port:
                   number: 80
-            path: /jwkms
+            path: /jwkms/
             pathType: Prefix
   tls:
     - hosts:


### PR DESCRIPTION
This ingress will parse the client certificate if supplied, allowing a combination of calls which use a client cert and those which do not. This is required because some calls into the /jwkms APIs extract data from the client cert in order to populate the SSA etc.

The ingress grants access to the /jwkms APIs in IG. It can be removed if a deployment does not want to support the Test Trusted Directory.

https://github.com/SecureApiGateway/SecureApiGateway/issues/828