### PR TITLE
777: Adding IG_OB_ASPSP_ORG_ID configuration

### DIFF
--- a/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
+++ b/kustomize/overlay/7.1.0/securebanking/defaults/configmap.yaml
@@ -21,6 +21,7 @@ data:
   CERT_ISSUER: null-issuer
   IG_INTERNAL_SVC: ig
   IG_TRUSTSTORE_PATH: /secrets/truststore/igtruststore
+  IG_OB_ASPSP_ORG_ID: 0015800001041REAAY
   IG_OB_ASPSP_SIGNING_KEYSTORE_PATH: /secrets/open-banking/ig-ob-signing-key.p12
   IG_OB_ASPSP_SIGNING_KEYSTORE_TYPE: PKCS12
   IG_OB_ASPSP_SIGNING_KEYSTORE_ALIAS: jwtsigner


### PR DESCRIPTION
This config contains the Open Banking issued Organisation Id for the ASPSP.

https://github.com/SecureApiGateway/SecureApiGateway/issues/777