### PR TITLE
749: Moving RCS config into the platform config

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/configmap.yaml
+++ b/kustomize/overlay/7.2.0/defaults/configmap.yaml
@@ -13,7 +13,7 @@ data:
   ENVIRONMENT_TYPE: CDK
   RS_INTERNAL_SVC: securebanking-openbanking-uk-rs
   # RCS connection settings for the RS API
-  RS_API_URI: http://securebanking-openbanking-uk-rs:80
+  RS_API_URI: http://securebanking-openbanking-uk-rs:8080
   # RCS connection settings for the Consent Repo (hosted by IG)
   RCS_CONSENT_REPO_URI: http://ig:80
   RCS_API_INTERNAL_SVC: securebanking-openbanking-uk-rcs

--- a/kustomize/overlay/7.2.0/defaults/configmap.yaml
+++ b/kustomize/overlay/7.2.0/defaults/configmap.yaml
@@ -12,6 +12,10 @@ data:
   # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
   ENVIRONMENT_TYPE: CDK
   RS_INTERNAL_SVC: securebanking-openbanking-uk-rs
+  # RCS connection settings for the RS API
+  RS_API_URI: http://securebanking-openbanking-uk-rs:80
+  # RCS connection settings for the Consent Repo (hosted by IG)
+  RCS_CONSENT_REPO_URI: http://ig:80
   RCS_API_INTERNAL_SVC: securebanking-openbanking-uk-rcs
   RCS_UI_INTERNAL_SVC: securebanking-ui-rcs-ui
   RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID: rcs-jwt-signer


### PR DESCRIPTION
749: Adding platform config for the internal APIs used by the RCS

- RS_API_URI , uri to access the RS API
- RCS_CONSENT_REPO_URI, uri to access the consent repo

See related RCS PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/98

https://github.com/SecureApiGateway/SecureApiGateway/issues/749