### PR TITLE
749: Renaming RCS_CONSENT_REPO_URI to CONSENT_REPO_URI

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/configmap.yaml
+++ b/kustomize/overlay/7.2.0/defaults/configmap.yaml
@@ -14,8 +14,8 @@ data:
   RS_INTERNAL_SVC: securebanking-openbanking-uk-rs
   # RCS connection settings for the RS API
   RS_API_URI: http://securebanking-openbanking-uk-rs:8080
-  # RCS connection settings for the Consent Repo (hosted by IG)
-  RCS_CONSENT_REPO_URI: http://ig:80
+  # Connection settings for the Consent Repo (hosted by IG)
+  CONSENT_REPO_URI: http://ig:80
   RCS_API_INTERNAL_SVC: securebanking-openbanking-uk-rcs
   RCS_UI_INTERNAL_SVC: securebanking-ui-rcs-ui
   RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID: rcs-jwt-signer


### PR DESCRIPTION
CONSENT_REPO_URI is used by both RCS and RS

https://github.com/SecureApiGateway/SecureApiGateway/issues/749