### PR TITLE
Revert 851 - Update Cluster Objects with new naming conventions

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/configmap.yaml
+++ b/kustomize/overlay/7.2.0/defaults/configmap.yaml
@@ -15,7 +15,7 @@ data:
   # RCS connection settings for the RS API
   RS_API_URI: http://test-facility-bank:8080
   # Connection settings for the Consent Repo (hosted by IG)
-  CONSENT_REPO_URI: http://secure-api-gateway:80
+  CONSENT_REPO_URI: http://ig:80
   RCS_API_INTERNAL_SVC: remote-consent-service
   RCS_UI_INTERNAL_SVC: remote-consent-service-user-interface
   RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID: rcs-jwt-signer

--- a/kustomize/overlay/7.2.0/defaults/deployment.yaml
+++ b/kustomize/overlay/7.2.0/defaults/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: secure-api-gateway
+  name: ig
 spec:
   template:
     spec:
@@ -30,7 +30,7 @@ spec:
               value: "/var/run/secrets/truststore/ig-truststore.pem"
 
       containers:
-      - name: secure-api-gateway
+      - name: ig
         envFrom:
         - secretRef:
             name: openig-secrets-env

--- a/kustomize/overlay/7.2.0/defaults/deployment.yaml
+++ b/kustomize/overlay/7.2.0/defaults/deployment.yaml
@@ -3,16 +3,7 @@ kind: Deployment
 metadata:
   name: secure-api-gateway
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: ig
   template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: ig
     spec:
       initContainers:
         # Copies certs from the ig-truststore-pem into the new-truststore volume
@@ -40,39 +31,12 @@ spec:
 
       containers:
       - name: secure-api-gateway
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         envFrom:
         - secretRef:
             name: openig-secrets-env
         - configMapRef:
             name: deployment-config
         imagePullPolicy: Always
-        image: ig
-        livenessProbe:
-          httpGet:
-            path: /kube/liveness
-            port: 8080
-          periodSeconds: 30
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /kube/readiness
-            port: 8080
-          initialDelaySeconds: 5
-        ports:
-        - containerPort: 8080   
-        resources:
-          requests:
-            cpu: 200m
-            memory: 512Mi
         volumeMounts:
           - name: new-truststore
             mountPath: /var/ig/secrets/truststore

--- a/kustomize/overlay/7.2.0/defaults/kustomization.yaml
+++ b/kustomize/overlay/7.2.0/defaults/kustomization.yaml
@@ -2,13 +2,13 @@ namespace: dev
 commonLabels:
   app.kubernetes.io/name: "forgerock"
 resources:
-- deployment.yaml
 - securebanking
 - kustomizeConfig
 - ingress.yaml
 
 patchesStrategicMerge:
   - configmap.yaml
+  - deployment.yaml
   - secret.yaml
 
 images:


### PR DESCRIPTION
We want the name to go back to IG for the time being

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/851