### PR TITLE
993: Add mongodb root password to configmap to be used elsewhere

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/secret.yaml
+++ b/kustomize/overlay/7.2.0/defaults/secret.yaml
@@ -19,3 +19,4 @@ data:
   IG_IDM_PASSWORD: MHBlbkJhbmtpbmch
   IG_AGENT_ID: aWctYWdlbnQ=
   IG_AGENT_PASSWORD: cGFzc3dvcmQ=
+  MONGODB_ROOT_PASSWORD: Rzg3SEVxdXNOaA==


### PR DESCRIPTION
Add new mongodb root password value to secrets configmap to be used elsewhere

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/993