### PR TITLE
968: Adding OB_ASPSP_SOFTWARE_ID config

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/configmap.yaml
+++ b/kustomize/overlay/7.2.0/defaults/configmap.yaml
@@ -25,6 +25,7 @@ data:
   USER_OBJECT: user
   CERT_ISSUER: null-issuer
   OB_ASPSP_ORG_ID: 0015800001041REAAY
+  OB_ASPSP_SOFTWARE_ID: YZyyZHejcCGRrWkh3OfkLI
   IG_INTERNAL_SVC: ig
   IG_TRUSTSTORE_PATH: /secrets/truststore/igtruststore
   IG_OB_ASPSP_SIGNING_KEYSTORE_PATH: /secrets/open-banking/ig-ob-signing-key.p12


### PR DESCRIPTION
This is the software_id in the Open Banking directory for the ASPSP software statement that this deployment represents.

https://github.com/SecureApiGateway/SecureApiGateway/issues/968