### PR TITLE
1082: Renaming config value CONSENT_REPO_URI => GATEWAY_DATA_REPO_URI

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/configmap.yaml
+++ b/kustomize/overlay/7.2.0/defaults/configmap.yaml
@@ -14,8 +14,8 @@ data:
   RS_INTERNAL_SVC: test-facility-bank
   # RCS connection settings for the RS API
   RS_API_URI: http://test-facility-bank:8080
-  # Connection settings for the Consent Repo (hosted by IG)
-  CONSENT_REPO_URI: http://ig:80
+  # Connection settings for the IG hosted data repo
+  GATEWAY_DATA_REPO_URI: http://ig:80
   RCS_CONSENT_STORE_URI: http://remote-consent-service:8080/consent/store
   RCS_API_INTERNAL_SVC: remote-consent-service
   RCS_UI_INTERNAL_SVC: remote-consent-service-user-interface


### PR DESCRIPTION
The IG internal repo route no longer supports fetching Consents from IDM. It is still used to fetch ApiClient and User data internally.

Renaming the configuration to `GATEWAY_DATA_REPO_URI` to make it clear that this relates to the IG repo route.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1082