### PR TITLE
918: Update annotations 

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/ingress.yaml
+++ b/kustomize/overlay/7.2.0/defaults/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
-    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
@@ -53,7 +52,6 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
@@ -109,7 +107,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
-    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/kustomize/overlay/7.2.0/defaults/ingress.yaml
+++ b/kustomize/overlay/7.2.0/defaults/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
-    nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -52,7 +52,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -107,7 +107,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
-    nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"

--- a/kustomize/overlay/7.2.0/defaults/ingress.yaml
+++ b/kustomize/overlay/7.2.0/defaults/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
     nginx.ingress.kubernetes.io/http2-max-field-size: 16k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -54,7 +54,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/http2-max-field-size: 16k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -110,7 +110,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
     nginx.ingress.kubernetes.io/http2-max-field-size: 16k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 128k
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"


### PR DESCRIPTION
Some annotations are now obsolete

Updating and increasing nginx version 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/918