### PR TITLE
1202: Update pipeline commands to later versions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,12 +23,12 @@ jobs:
         uses: tj-actions/branch-names@v7
       
       - name: Auth to GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
       - name: Create lowercase Github Username
         id: toLowerCase


### PR DESCRIPTION
V0's are deprecated, updating to newer used versions

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1202