### PR TITLE
1288: Changes to cloud instance config for pushing to cloud tenant

### DIFF
--- a/nightly/id-cloud-config/realms/alpha/realm-config/authentication.json
+++ b/nightly/id-cloud-config/realms/alpha/realm-config/authentication.json
@@ -17,7 +17,7 @@
   },
   "core": {
     "adminAuthModule": "[Empty]",
-    "orgConfig": "PasswordGrant"
+    "orgConfig": "Login"
   },
   "general": {
     "defaultAuthLevel": 0,


### PR DESCRIPTION
As per https://github.com/ForgeCloud/saas/pull/9887 PasswordGrant is no longer valid for orgConfig so it has been changed to Login

NOTE: This change will also need to be made to ob-sandbox-v2 config and fr-platform-config

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1288