### PR TITLE
1326: Create SAPIG deployed slack notification

### DIFF
--- a/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
@@ -37,6 +37,11 @@ patches:
       kind: Deployment
       name: ig
     path: patch/deployment/ig-deployment-patch.yaml
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: core-deployment-config
+    path: patch/configmap/core-configmap-patch.yaml
   - patch: |-
       $patch: delete
       apiVersion: v1

--- a/ob/kustomize/overlay/7.3.0/defaults/patch/configmap/core-configmap-patch.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/patch/configmap/core-configmap-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace 
+  path: /data/SAPIG_TYPE
+  value: ob


### PR DESCRIPTION
Use patch to change value of `SAPIG_TYPE` within core-deployment-config from `core` to `ob` for OB deployments

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1326