### PR TITLE
1328: Change Individual Environments to use a dev IG Image

### DIFF
--- a/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: dev

--- a/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: dev

--- a/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: latest

--- a/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: latest

--- a/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: dev

--- a/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: latest

--- a/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
@@ -8,6 +8,6 @@ patchesStrategicMerge:
   - configmap.yaml
 
 images:
-- name: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
+- name: ig
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ig
   newTag: dev


### PR DESCRIPTION
The image repo that is to be replaces has gone back to being IG for OB where it was the core one

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1328