### PR TITLE
1351: Order the Cloud Config in various repos automatically

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,32 @@
+name: Check Json Order
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - README.md
+
+jobs:
+  checkcode:
+    name: Check Code
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+      - name: Sort Json Files
+        run: |
+          npm -g install sort-json
+          find ./ -name '*.json' -exec sort-json {} \;
+      - name: Commit changes
+        run: |
+          git config user.name fropenbanking
+          git config user.email obst@forgerock.com
+          git add .
+          git commit -m "Automated commit - Sorting json files - [skip ci]" || exit 0
+          git push


### PR DESCRIPTION
Sort json files on merge
Will commit directly to master as fropenbanking user
Won't run any further actions on commit due to [skip ci] in message, as this would cause unnecessary runs

Tested and working in - https://github.com/SecureApiGateway/fr-platform-config/actions/runs/8619619861

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1351