### PR TITLE
1315: Remove unwanted config from dev-core

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/deployment.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/deployment.yaml
@@ -41,9 +41,6 @@ spec:
           - name: new-truststore
             mountPath: /var/ig/secrets/truststore
             readOnly: true
-          - name: ig-ob-signing-key
-            mountPath: /var/ig/secrets/open-banking
-            readOnly: true
           - name: test-trusted-dir-keystore
             mountPath: /var/ig/secrets/test-trusted-directory
             readOnly: true
@@ -54,10 +51,6 @@ spec:
         - name: ig-truststore-pem
           secret:
             secretName: ig-truststore-pem
-            optional: false
-        - name: ig-ob-signing-key
-          secret:
-            secretName: ig-ob-signing-key
             optional: false
         - name: test-trusted-dir-keystore
           secret:

--- a/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
@@ -9,13 +9,13 @@
     secretRef:
       name: ob-secrets
 - op: add
-  path: "/spec/template/spec/containers/0/volumeMounts/2"
+  path: "/spec/template/spec/containers/0/volumeMounts/"
   value: 
     name: ig-ob-signing-key
     mountPath: /var/ig/secrets/open-banking
     readOnly: true
 - op: add
-  path: "/spec/template/spec/volumes/3"
+  path: "/spec/template/spec/volumes/"
   value: 
     name: ig-ob-signing-key
     secret:

--- a/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
@@ -8,16 +8,16 @@
   value:
     secretRef:
       name: ob-secrets
-#- op: add
-#  path: "/spec/template/spec/containers/0/volumeMounts/1"
-#  value: 
-#    name: ig-ob-signing-key
-#    mountPath: /var/ig/secrets/open-banking
-#    readOnly: true
-#- op: add
-#  path: "/spec/template/spec/volumes/2"
-#  value: 
-#    name: ig-ob-signing-key
-#    secret:
-#      secretName: ig-ob-signing-key
-#      optional: false
+- op: add
+  path: "/spec/template/spec/containers/0/volumeMounts/1"
+  value: 
+    name: ig-ob-signing-key
+    mountPath: /var/ig/secrets/open-banking
+    readOnly: true
+- op: add
+  path: "/spec/template/spec/volumes/2"
+  value: 
+    name: ig-ob-signing-key
+    secret:
+      secretName: ig-ob-signing-key
+      optional: false

--- a/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
@@ -8,16 +8,16 @@
   value:
     secretRef:
       name: ob-secrets
-- op: add
-  path: "/spec/template/spec/containers/0/volumeMounts/1"
-  value: 
-    name: ig-ob-signing-key
-    mountPath: /var/ig/secrets/open-banking
-    readOnly: true
-- op: add
-  path: "/spec/template/spec/volumes/2"
-  value: 
-    name: ig-ob-signing-key
-    secret:
-      secretName: ig-ob-signing-key
-      optional: false
+#- op: add
+#  path: "/spec/template/spec/containers/0/volumeMounts/1"
+#  value: 
+#    name: ig-ob-signing-key
+#    mountPath: /var/ig/secrets/open-banking
+#    readOnly: true
+#- op: add
+#  path: "/spec/template/spec/volumes/2"
+#  value: 
+#    name: ig-ob-signing-key
+#    secret:
+#      secretName: ig-ob-signing-key
+#      optional: false

--- a/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
@@ -8,3 +8,16 @@
   value:
     secretRef:
       name: ob-secrets
+- op: add
+  path: "/spec/template/spec/containers/0/volumeMounts/2"
+  value: 
+    name: ig-ob-signing-key
+    mountPath: /var/ig/secrets/open-banking
+    readOnly: true
+- op: add
+  path: "/spec/template/spec/volumes/3"
+  value: 
+    name: ig-ob-signing-key
+    secret:
+      secretName: ig-ob-signing-key
+      optional: false

--- a/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/patch/deployment/ig-deployment-patch.yaml
@@ -9,13 +9,13 @@
     secretRef:
       name: ob-secrets
 - op: add
-  path: "/spec/template/spec/containers/0/volumeMounts/"
+  path: "/spec/template/spec/containers/0/volumeMounts/1"
   value: 
     name: ig-ob-signing-key
     mountPath: /var/ig/secrets/open-banking
     readOnly: true
 - op: add
-  path: "/spec/template/spec/volumes/"
+  path: "/spec/template/spec/volumes/2"
   value: 
     name: ig-ob-signing-key
     secret:


### PR DESCRIPTION
We want to remove references to `ig-ob-signing-key` in core, but need it for OB
Removed any reference from deployment.yaml in core kustomize
Adding the values in via patches for OB

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315