### PR TITLE
754: Run initializer using Service Account

### DIFF
--- a/helm/external-secrets/templates/cloud-service-account.yaml
+++ b/helm/external-secrets/templates/cloud-service-account.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.environment.fr_platform.type "FIDC" }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloud-service-account
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h             
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-store 
+  target:
+    name: cloud-service-account
+    creationPolicy: Owner  
+  data:
+  - secretKey: private-key
+    remoteRef:
+      key: {{ .Release.Namespace}}-private-key
+  - secretKey: private-id
+    remoteRef:
+      key: {{ .Release.Namespace}}-private-id
+{{ end }}

--- a/helm/external-secrets/templates/cloud-service-account.yaml
+++ b/helm/external-secrets/templates/cloud-service-account.yaml
@@ -15,8 +15,8 @@ spec:
   data:
   - secretKey: private-key
     remoteRef:
-      key: {{ .Release.Namespace}}-private-key
+      key: nightly-private-key
   - secretKey: private-id
     remoteRef:
-      key: {{ .Release.Namespace}}-private-id
+      key: nightly-private-id
 {{ end }}


### PR DESCRIPTION
Add in template for creating cloud-service-account secret in the cluster

This service account will be used for the test data initialiser to authenticate to a cloud instance 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/754