### PR TITLE
1357: Update IG Kustomise Base Location to Match IG image being used

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/securebanking/kustomization.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/securebanking/kustomization.yaml
@@ -3,7 +3,7 @@ commonLabels:
   app.kubernetes.io/name: "forgerock"
 resources:
 # May need a nicer way of doing the release verison in future
-- https://github.com/ForgeRock/forgeops/kustomize/base/ig?ref=release/7.3-20230706
+- https://github.com/ForgeRock/forgeops/kustomize/base/ig?ref=release/7.5-20240402
 
 secretGenerator:
 - name: obri-ca


### PR DESCRIPTION
IG is currently using 2024.3.0 who's base files matches up to [7.5](https://github.com/ForgeRock/forgeops/blob/release/7.5-20240402/docker/ig/Dockerfile)

Updating the base resource used in Kustomise to match this

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1357