### PR TITLE
1367: Using the default pluginsConfig for oauth-oidc.json

### DIFF
--- a/cloud-config/nightly/id-cloud-config/realms/alpha/services/oauth-oidc.json
+++ b/cloud-config/nightly/id-cloud-config/realms/alpha/services/oauth-oidc.json
@@ -300,24 +300,5 @@
     "devicePollInterval": 5,
     "deviceUserCodeCharacterSet": "234567ACDEFGHJKLMNPQRSTWXYZabcdefhijkmnopqrstwxyz",
     "deviceUserCodeLength": 8
-  },
-  "pluginsConfig": {
-    "accessTokenEnricherClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "accessTokenModificationPluginType": "SCRIPTED",
-    "accessTokenModificationScript": "39c08084-1238-43e8-857f-2e11005eac49",
-    "accessTokenModifierClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "authorizeEndpointDataProviderClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "authorizeEndpointDataProviderPluginType": "JAVA",
-    "authorizeEndpointDataProviderScript": "[Empty]",
-    "evaluateScopeClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "evaluateScopePluginType": "JAVA",
-    "evaluateScopeScript": "[Empty]",
-    "oidcClaimsClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "oidcClaimsPluginType": "SCRIPTED",
-    "oidcClaimsScript": "36863ffb-40ec-48b9-94b1-9a99f71cc3b5",
-    "userCodeGeneratorClass": "org.forgerock.oauth2.core.plugins.registry.DefaultUserCodeGenerator",
-    "validateScopeClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "validateScopePluginType": "JAVA",
-    "validateScopeScript": "[Empty]"
   }
 }

--- a/cloud-config/nightly/id-cloud-config/realms/bravo/services/oauth-oidc.json
+++ b/cloud-config/nightly/id-cloud-config/realms/bravo/services/oauth-oidc.json
@@ -251,24 +251,5 @@
     "devicePollInterval": 5,
     "deviceUserCodeCharacterSet": "234567ACDEFGHJKLMNPQRSTWXYZabcdefhijkmnopqrstwxyz",
     "deviceUserCodeLength": 8
-  },
-  "pluginsConfig": {
-    "accessTokenEnricherClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "accessTokenModificationPluginType": "SCRIPTED",
-    "accessTokenModificationScript": "21138ab1-0621-4466-b18f-670bfcbabca7",
-    "accessTokenModifierClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "authorizeEndpointDataProviderClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "authorizeEndpointDataProviderPluginType": "JAVA",
-    "authorizeEndpointDataProviderScript": "[Empty]",
-    "evaluateScopeClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "evaluateScopePluginType": "JAVA",
-    "evaluateScopeScript": "[Empty]",
-    "oidcClaimsClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "oidcClaimsPluginType": "SCRIPTED",
-    "oidcClaimsScript": "36863ffb-40ec-48b9-94b1-9a99f71cc3b5",
-    "userCodeGeneratorClass": "org.forgerock.oauth2.core.plugins.registry.DefaultUserCodeGenerator",
-    "validateScopeClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "validateScopePluginType": "JAVA",
-    "validateScopeScript": "[Empty]"
   }
 }


### PR DESCRIPTION
Omitting the pluginsConfig for the oauth-oidc.json config file, with the intention of using the tenant default values.

SAPIG does not currently rely on any customisation of pluginsConfig.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1367