### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/workflows/pr-core.yaml
+++ b/.github/workflows/pr-core.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_pr-template:
     name: PR - Build and Deploy
-    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@1389-standard-steps-for-workflows
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@main
     secrets: inherit
     with:
       componentName: sapig-openbanking-uk-developer-envs

--- a/.github/workflows/pr-core.yaml
+++ b/.github/workflows/pr-core.yaml
@@ -1,6 +1,5 @@
 name: PR - Build and Deploy
 on:
-  push: #Temp for testing
   pull_request:
     branches:
       - master

--- a/.github/workflows/pr-core.yaml
+++ b/.github/workflows/pr-core.yaml
@@ -14,4 +14,3 @@ jobs:
     with:
       componentName: sapig-openbanking-uk-developer-envs
       sapigType: core
-      serviceName: secure-api-gateway-core

--- a/.github/workflows/pr-core.yaml
+++ b/.github/workflows/pr-core.yaml
@@ -1,6 +1,6 @@
 name: PR - Build and Deploy
 on:
-  workflow_dispatch: #Temp for testing
+  push: #Temp for testing
   pull_request:
     branches:
       - master

--- a/.github/workflows/pr-core.yaml
+++ b/.github/workflows/pr-core.yaml
@@ -1,50 +1,17 @@
-name: Pull Request - Build and Deploy - Core
-
+name: PR - Build and Deploy
 on:
+  workflow_dispatch: #Temp for testing
   pull_request:
     branches:
       - master
-    paths: 
+    paths:
       - 'core/**'
-
-env:
-  PR_NUMBER: pr-${{ github.event.number }}
-  SERVICE_NAME: ig-devenv
-  SAPIG_TYPE: core
-
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    name: Deploy
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Get Branch
-        id: branch-name
-        uses: tj-actions/branch-names@v7
-      
-      - name: Auth to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.DEV_GAR_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.0
-
-      - name: Create lowercase Github Username
-        id: toLowerCase
-        run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
-      
-      - name: Output User Env Var
-        run: echo "GITHUB_USER set to ${{ env.GITHUB_USER }}"
-      
-      - name: 'Build Environment'
-        uses: codefresh-io/codefresh-pipeline-runner@master
-        with:
-          args: '-v NEWBRANCH=${{ steps.branch-name.outputs.current_branch }} -v SERVICE_NAME=${{ env.SERVICE_NAME }} -v ENVIRONMENT=${{ env.GITHUB_USER }}-${{ env.SAPIG_TYPE }}'
-        env:
-          PIPELINE_NAME: 'SAPIG-devenv/dev-core-service-build'
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          TRIGGER_NAME: github-actions-trigger-devenvs
-          CF_BRANCH: master
-        id: run-pipeline
+  run_pr-template:
+    name: PR - Build and Deploy
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@1389-standard-steps-for-workflows
+    secrets: inherit
+    with:
+      componentName: sapig-openbanking-uk-developer-envs
+      sapigType: core
+      serviceName: secure-api-gateway-core

--- a/.github/workflows/pr-ob.yaml
+++ b/.github/workflows/pr-ob.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_pr-template:
     name: PR - Build and Deploy
-    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@1389-standard-steps-for-workflows
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@main
     secrets: inherit
     with:
       componentName: sapig-openbanking-uk-developer-envs

--- a/.github/workflows/pr-ob.yaml
+++ b/.github/workflows/pr-ob.yaml
@@ -1,51 +1,17 @@
-name: Pull Request - Build and Deploy - OB
-
+name: PR - Build and Deploy
 on:
+  workflow_dispatch: #Temp for testing
   pull_request:
     branches:
       - master
-    paths: 
+    paths:
       - 'ob/**'
-
-env:
-  PR_NUMBER: pr-${{ github.event.number }}
-  SERVICE_NAME: ig-devenv
-  SAPIG_TYPE: ob
-
-
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    name: Deploy
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Get Branch
-        id: branch-name
-        uses: tj-actions/branch-names@v7
-      
-      - name: Auth to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.DEV_GAR_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.0
-
-      - name: Create lowercase Github Username
-        id: toLowerCase
-        run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
-      
-      - name: Output User Env Var
-        run: echo "GITHUB_USER set to ${{ env.GITHUB_USER }}"
-      
-      - name: 'Build Environment'
-        uses: codefresh-io/codefresh-pipeline-runner@master
-        with:
-          args: '-v NEWBRANCH=${{ steps.branch-name.outputs.current_branch }} -v SERVICE_NAME=${{ env.SERVICE_NAME }} -v ENVIRONMENT=${{ env.GITHUB_USER }}-${{ env.SAPIG_TYPE }}'
-        env:
-          PIPELINE_NAME: 'SAPIG-devenv/dev-ob-service-build'
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          TRIGGER_NAME: github-actions-trigger-devenvs
-          CF_BRANCH: master
-        id: run-pipeline
+  run_pr-template:
+    name: PR - Build and Deploy
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@1389-standard-steps-for-workflows
+    secrets: inherit
+    with:
+      componentName: sapig-openbanking-uk-developer-envs
+      sapigType: ob
+      serviceName: secure-api-gateway-ob

--- a/.github/workflows/pr-ob.yaml
+++ b/.github/workflows/pr-ob.yaml
@@ -1,6 +1,5 @@
 name: PR - Build and Deploy
 on:
-  workflow_dispatch: #Temp for testing
   pull_request:
     branches:
       - master

--- a/.github/workflows/pr-ob.yaml
+++ b/.github/workflows/pr-ob.yaml
@@ -13,4 +13,3 @@ jobs:
     with:
       componentName: sapig-openbanking-uk-developer-envs
       sapigType: ob
-      serviceName: secure-api-gateway-ob

--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -1,18 +1,10 @@
-name: Check Changes
-
+name: Merge Notification
 on:
   push:
     branches:
       - master
-
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    name: Push Slack Notification
-    steps:
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: success()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.WEBHOOK_SBAT_DEV_SLACK }}
-          SLACK_COLOR: ${{ job.status }}
+  run_slack-notification:
+    name: Merge Notification
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-slack-notification.yml@main
+    secrets: inherit


### PR DESCRIPTION
Amend PR Slack Notify & Merge workflow to use steps in CI Repo
Standardise workflows in the process of doing this

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389