### PR TITLE
1305: Adding the AM /par path to the MTLS ingress

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -42,6 +42,13 @@ spec:
                 name: ig
                 port:
                   number: 80
+            path: /am/oauth2/realms/root/realms/alpha/par
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
             path: /rs/
             pathType: Prefix
   tls:


### PR DESCRIPTION
MTLS needs to be used when doing PAR (Pushed Authorisation Request).

Related core PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/30

https://github.com/SecureApiGateway/SecureApiGateway/issues/1305