### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release - Build, Deploy & Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseNotes:
+        description: "Release Notes - Issues Included in Release"
+        required: false
+        type: string
+      releaseVersion:
+        description: "The version to be Released (#.#.#.#)"
+        required: true
+        type: string
+jobs:
+  run_release-template:
+    name: Release - Build, Deploy & Create Release
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@1389-standard-steps-for-workflows
+    secrets: inherit
+    with:
+      componentName: sapig-openbanking-uk-developer-envs
+      releaseNotes: ${{ inputs.releaseNotes }}
+      releaseVersion: ${{ inputs.releaseVersion }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       releaseVersion:
-        description: "The version to be Released (#.#.#.#)"
+        description: "The version to be Released (#.#.# | #.#.#-rc#)"
         required: true
         type: string
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release - Build, Deploy & Create Release
+run-name: "${{ inputs.releaseVersion }}: Release - Build, Deploy & Create Release"
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +14,7 @@ on:
 jobs:
   run_release-template:
     name: Release - Build, Deploy & Create Release
-    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@1389-standard-steps-for-workflows
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@main
     secrets: inherit
     with:
       componentName: sapig-openbanking-uk-developer-envs


### PR DESCRIPTION
Amend release workflow to use reusable CI repo workflow

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389