### PR TITLE
Revert "1305: Adding the AM /par path to the MTLS ingress (#110)"

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -42,13 +42,6 @@ spec:
                 name: ig
                 port:
                   number: 80
-            path: /am/oauth2/realms/root/realms/alpha/par
-            pathType: Prefix
-          - backend:
-              service:
-                name: ig
-                port:
-                  number: 80
             path: /rs/
             pathType: Prefix
   tls:


### PR DESCRIPTION
This reverts commit e0cdd005bae4f452e81e65052272fc278aee2240.

Related core PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/42