### PR TITLE
1342: Create k8s deployment for Test Trusted Directory

### DIFF
--- a/test-trusted-directory/kustomize/bohocode/configmap.yaml
+++ b/test-trusted-directory/kustomize/bohocode/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: test-trusted-directory-config
 data:
   IG_FQDN: "sapig.bohocode-core.forgerock.financial"
-  IDENTITY_PLATFORM_FQDN: "iam.bohocode-core.forgerock.financial"

--- a/test-trusted-directory/kustomize/dbadham-fr/configmap.yaml
+++ b/test-trusted-directory/kustomize/dbadham-fr/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: test-trusted-directory-config
 data:
   IG_FQDN: "sapig.dbadham-fr-core.forgerock.financial"
-  IDENTITY_PLATFORM_FQDN: "iam.dbadham-fr-core.forgerock.financial"

--- a/test-trusted-directory/kustomize/defaults/configmap.yaml
+++ b/test-trusted-directory/kustomize/defaults/configmap.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: test-trusted-directory-config
 data:
-  AM_REALM: "bravo"
   IG_TEST_DIRECTORY_ISSUER_NAME: "test-publisher"
   IG_TEST_DIRECTORY_CA_KEYSTORE_ALIAS: "ca"
   IG_TEST_DIRECTORY_CA_KEYSTORE_PATH: "/secrets/test-trusted-directory/test-trusted-dir-keystore.p12"

--- a/test-trusted-directory/kustomize/defaults/configmap.yaml
+++ b/test-trusted-directory/kustomize/defaults/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: test-trusted-directory-config
 data:
-  AM_REALM: "alpha"
+  AM_REALM: "bravo"
   IG_TEST_DIRECTORY_ISSUER_NAME: "test-publisher"
   IG_TEST_DIRECTORY_CA_KEYSTORE_ALIAS: "ca"
   IG_TEST_DIRECTORY_CA_KEYSTORE_PATH: "/secrets/test-trusted-directory/test-trusted-dir-keystore.p12"

--- a/test-trusted-directory/kustomize/dev/configmap.yaml
+++ b/test-trusted-directory/kustomize/dev/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: test-trusted-directory-config
 data:
   IG_FQDN: "sapig.dev-core.forgerock.financial"
-  IDENTITY_PLATFORM_FQDN: "iam.dev-core.forgerock.financial"

--- a/test-trusted-directory/kustomize/nightly/configmap.yaml
+++ b/test-trusted-directory/kustomize/nightly/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: test-trusted-directory-config
 data:
   IG_FQDN: "sapig.nightly-core.forgerock.financial"
-  IDENTITY_PLATFORM_FQDN: "iam.nightly-core.forgerock.financial"

--- a/test-trusted-directory/kustomize/shaunharrisonfr/configmap.yaml
+++ b/test-trusted-directory/kustomize/shaunharrisonfr/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: test-trusted-directory-config
 data:
   IG_FQDN: "sapig.shaunharrisonfr-core.forgerock.financial"
-  IDENTITY_PLATFORM_FQDN: "iam.shaunharrisonfr-core.forgerock.financial"


### PR DESCRIPTION
Remove unwanted `AM_REALM` & `IDENTITY_PLATFORM_FQDN` as config no longer required

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1342