### PR TITLE
1342: Create k8s deployment for Test Trusted Directory

### DIFF
--- a/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -1,0 +1,37 @@
+---
+# Ingress for the Test Trusted Directory hosted by the gateway.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: test-trusted-directory
+spec:
+  rules:
+    - host: $(FQDN)
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /jwkms/
+            pathType: Prefix
+  tls:
+    - hosts:
+        - $(FQDN)
+      secretName: sslcert

--- a/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
@@ -12,11 +12,11 @@ generatorOptions:
   disableNameSuffixHash: true
 
 resources:
-- https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/core/kustomize/overlay/7.3.0/defaults?ref=master
+  - https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/core/kustomize/overlay/7.3.0/defaults?ref=master
+  - ingress.yaml
 
 patchesStrategicMerge:
   - configmap.yaml
-  - ingress.yaml
   - secret.yaml
 
 images:

--- a/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 
 patchesStrategicMerge:
   - configmap.yaml
+  - ingress.yaml
   - secret.yaml
 
 images:


### PR DESCRIPTION
Add in ingress to OB for test trusted dir, was previously in Core kustomise files but now core is using a separate trusted dir

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1342