### PR TITLE
1456: Update Kustomise templates

### DIFF
--- a/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/bohocode/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:

--- a/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dbadham-fr/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:

--- a/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/dev/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:

--- a/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/devops/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:

--- a/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/frlaura-jianu/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:

--- a/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/nightly/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:

--- a/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
@@ -57,6 +57,26 @@ replacements:
           name: mtls
           version: v1
   - source:
+      fieldPath: data.IG_FQDN
+      kind: ConfigMap
+      name: core-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.rules.0.host
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+      - fieldPaths:
+          - spec.tls.0.hosts.0
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
+  - source:
       fieldPath: metadata.namespace
       kind: ConfigMap
       name: core-deployment-config

--- a/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
@@ -91,5 +91,20 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: test-trusted-directory-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: test-trusted-directory
+          version: v1
 resources:
   - ../defaults

--- a/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/shaunharrisonfr/kustomization.yaml
@@ -91,12 +91,6 @@ replacements:
           kind: Ingress
           name: mtls
           version: v1
-  - source:
-      fieldPath: metadata.namespace
-      kind: ConfigMap
-      name: test-trusted-directory-config
-      version: v1
-    targets:
       - fieldPaths:
           - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
         options:


### PR DESCRIPTION
Missing replacements config for fixing test-trusted-directory ingress

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1456