### PR TITLE
1469: Par endpoint is not having the realm changed from alpha to bravo

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/deployment.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,7 +29,6 @@ spec:
             # Path to the pem file containing the certs to copy into the new truststore
             - name: IG_PEM_TRUSTSTORE
               value: "/var/run/secrets/truststore/ig-truststore.pem"
-
       containers:
       - name: ig
         envFrom:

--- a/core/kustomize/overlay/7.3.0/defaults/kustomization.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/kustomization.yaml
@@ -3,9 +3,9 @@ images:
   newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-core
   newTag: latest
 patches:
-- path: configmap.yaml
-- path: deployment.yaml
-- path: secret.yaml
+  - path: configmap.yaml
+  - path: deployment.yaml
+  - path: secret.yaml
 resources:
-- ingress.yaml
-- securebanking
+  - ingress.yaml
+  - securebanking

--- a/core/kustomize/overlay/7.3.0/defaults/secret.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/secret.yaml
@@ -4,12 +4,12 @@ metadata:
   name: core-secrets
 type: Opaque
 data:
-  IG_METRICS_USERNAME: dXNlcg==
-  IG_METRICS_PASSWORD: cGFzc3dvcmQ=
-  IG_TRUSTSTORE_PASSWORD: Y2hhbmdlaXQ=
+  IG_AGENT_ID: aWctYWdlbnQ=
+  IG_AGENT_PASSWORD: cGFzc3dvcmQ=
   IG_CLIENT_ID: aWctY2xpZW50
   IG_CLIENT_SECRET: cGFzc3dvcmQ=
   IG_IDM_USER: c2VydmljZV9hY2NvdW50Lmln
   IG_IDM_PASSWORD: MHBlbkJhbmtpbmch
-  IG_AGENT_ID: aWctYWdlbnQ=
-  IG_AGENT_PASSWORD: cGFzc3dvcmQ=
+  IG_METRICS_USERNAME: dXNlcg==
+  IG_METRICS_PASSWORD: cGFzc3dvcmQ=
+  IG_TRUSTSTORE_PASSWORD: Y2hhbmdlaXQ=

--- a/core/kustomize/overlay/7.3.0/nightly/patch/ingress/mtls-ingress-patch.yaml
+++ b/core/kustomize/overlay/7.3.0/nightly/patch/ingress/mtls-ingress-patch.yaml
@@ -4,3 +4,6 @@
 - op: replace 
   path: /spec/rules/0/http/paths/1/path
   value: /am/oauth2/realms/root/realms/bravo/register
+- op: replace
+  path: /spec/rules/0/http/paths/2/path
+  value: /am/oauth2/realms/root/realms/bravo/par


### PR DESCRIPTION
- Add in replace command for par endpoint to point to bravo realm
- Reorder some files for standardisation

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1469