### PR TITLE
1509: Review k8s ingress annotations

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
@@ -61,7 +60,6 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
@@ -95,7 +93,6 @@ metadata:
   name: ig-web
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/rewrite-target: "/$2"
 spec:
   ingressClassName: nginx

--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
@@ -19,6 +18,7 @@ metadata:
     nginx.ingress.kubernetes.io/error-log-level: "debug"
   name: mtls
 spec:
+  ingressClassName: nginx
   rules:
     - host: MTLS_FQDN_PLACEHOLDER
       http:
@@ -61,7 +61,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
@@ -74,6 +73,7 @@ metadata:
     nginx.ingress.kubernetes.io/error-log-level: "debug"
   name: forgerock
 spec:
+  ingressClassName: nginx
   rules:
     - host: FQDN_PLACEHOLDER
       http:
@@ -96,12 +96,12 @@ kind: Ingress
 metadata:
   name: ig-web
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
     nginx.ingress.kubernetes.io/rewrite-target: "/$2"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - FQDN_PLACEHOLDER

--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
@@ -63,7 +62,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
     nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
@@ -98,7 +96,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
     nginx.ingress.kubernetes.io/rewrite-target: "/$2"
 spec:
   ingressClassName: nginx

--- a/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca

--- a/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -5,7 +5,6 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca

--- a/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -4,7 +4,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
@@ -20,6 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/error-log-level: "debug"
   name: test-trusted-directory
 spec:
+  ingressClassName: nginx
   rules:
     - host: FQDN_PLACEHOLDER
       http:

--- a/test-trusted-directory/kustomize/defaults/ingress.yaml
+++ b/test-trusted-directory/kustomize/defaults/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca

--- a/test-trusted-directory/kustomize/defaults/ingress.yaml
+++ b/test-trusted-directory/kustomize/defaults/ingress.yaml
@@ -5,7 +5,6 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca

--- a/test-trusted-directory/kustomize/defaults/ingress.yaml
+++ b/test-trusted-directory/kustomize/defaults/ingress.yaml
@@ -4,7 +4,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: “HTTPS"
@@ -20,6 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/error-log-level: "debug"
   name: test-trusted-directory
 spec:
+  ingressClassName: nginx
   rules:
     - host: FQDN_PLACEHOLDER
       http:


### PR DESCRIPTION
- Remove deprecated annotation and use ingressClassName instead
- Remove unwanted backend protocol declaration 


Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1509