### PR TITLE
1512: SAPI-G ingress pass all traffic to ig pod

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -79,7 +79,7 @@ spec:
                 name: ig
                 port:
                   number: 80
-            path: /am/
+            path: /
             pathType: Prefix
   tls:
     - hosts:


### PR DESCRIPTION
All traffic which does not match a more specific rule is now routed to the IG pod. This allows us to reverse proxy identity platform without having to know all of the possible paths that might need to be accessed.

See related IG PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/65

https://github.com/SecureApiGateway/SecureApiGateway/issues/1512