### PR TITLE
1529: Rename ApiClient.id field to softwareId

### DIFF
--- a/cloud-config/nightly/id-cloud-config/managed-objects/apiClient/apiClient.json
+++ b/cloud-config/nightly/id-cloud-config/managed-objects/apiClient/apiClient.json
@@ -1,6 +1,11 @@
 {
   "iconClass": "fa fa-database",
   "name": "apiClient",
+  "onRead": {
+    "type": "text/javascript",
+    "globals": {},
+    "source": "if (object.softwareId == null) {\n  object.softwareId = object.id\n}"
+  },
   "schema": {
     "$schema": "http://forgerock.org/json-schema#",
     "description": "Secure Banking apiClient",
@@ -8,7 +13,7 @@
     "mat-icon": null,
     "order": [
       "_id",
-      "id",
+      "softwareId",
       "name",
       "description",
       "deleted",
@@ -104,6 +109,16 @@
         "userEditable": true,
         "viewable": true
       },
+      "softwareId": {
+        "deleteQueryConfig": false,
+        "description": null,
+        "isVirtual": false,
+        "searchable": true,
+        "title": "Software ID",
+        "type": "string",
+        "userEditable": true,
+        "viewable": true
+      },
       "jwks": {
         "searchable": false,
         "title": "JWK Set",
@@ -164,7 +179,6 @@
       }
     },
     "required": [
-      "id",
       "name",
       "oauth2ClientId",
       "ssa",


### PR DESCRIPTION
Changes from https://github.com/SecureApiGateway/fr-platform-config/pull/60

Running into Nightly Core to test via [Codefresh Build](https://g.codefresh.io/pipelines/edit/new/builds?activeAccountId=5bc76f3a8249cc15fa883acb&id=649e9c370f4a96d3d4e2ee9e&pipeline=nightly-cloud-config-manager&projects=SAPIG-devenv&projectId=660569480f598adcee01dd92) - and changing `REPO_DEVELOPER_ENVS_BRANCH` to this branch name

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1529