### PR TITLE
1566: Revert Repos back to master|main - support v4.0 of UK Open Banking Specifications

### DIFF
--- a/core/kustomize/overlay/nightly/configmap.yaml
+++ b/core/kustomize/overlay/nightly/configmap.yaml
@@ -8,7 +8,7 @@ data:
   IG_FQDN: "sapig.nightly-core.forgerock.financial"
   MTLS_FQDN: "mtls.sapig.nightly-core.forgerock.financial"
   TRUSTEDDIR_FQDN: "test-trusted-directory.nightly-core.forgerock.financial"
-  IDENTITY_PLATFORM_FQDN: "openam-fahrenheit-sm.forgeblocks.com"
+  IDENTITY_PLATFORM_FQDN: "openam-sapig-nightly.forgeblocks.com"
   AM_REALM: "bravo"
   USER_OBJECT: "bravo_user"
   IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE: "PasswordGrant"


### PR DESCRIPTION
Correct AIC URL for nightly-core

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1566