### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/core/kustomize/overlay/bohocode/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/bohocode/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: bohocode-core
 patches:

--- a/core/kustomize/overlay/dev-aic/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/dev-aic/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: dev-aic-core
 patches:

--- a/core/kustomize/overlay/dev-cdk/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/dev-cdk/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: dev-cdk-core
 patches:

--- a/core/kustomize/overlay/devops/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/devops/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: devops-core
 patches:

--- a/core/kustomize/overlay/guillaumelamirand/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/guillaumelamirand/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: guillaumelamirand-core
 patches:

--- a/core/kustomize/overlay/openig-nightly/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/openig-nightly/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: openig-nightly-core
 patches:

--- a/core/kustomize/overlay/shaunharrisonfr/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/shaunharrisonfr/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: shaunharrisonfr-core
 patches:

--- a/core/kustomize/overlay/wmorrison365fr/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/wmorrison365fr/fapi-pep-rs/kustomization.yaml
@@ -2,7 +2,7 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
     - name: fapi-pep-rs
-      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs
+      newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/fapi-pep-rs-core
       newTag:  latest
 namespace: wmorrison365fr-core
 patches:


### PR DESCRIPTION
Correct name in the overlay for fapi-pep-rs-core

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676