### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/core/kustomize/overlay/dev-aic/fapi-pep-as/kustomization.yaml
+++ b/core/kustomize/overlay/dev-aic/fapi-pep-as/kustomization.yaml
@@ -7,7 +7,7 @@ patches:
 - target:
     version: v1
     kind: Ingress
-    name: mtls
+    name: as-mtls
   path: patch/ingress/mtls-ingress-patch.yaml
 replacements:
   - source:


### PR DESCRIPTION
Correct ingress name for patch

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676