### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/core/kustomize/overlay/bohocode/fapi-pep-as/configmap.yaml
+++ b/core/kustomize/overlay/bohocode/fapi-pep-as/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: core-deployment-config
+  name: as-sapig-deployment-config
 data:
   AS_FQDN: "as-sapig.bohocode-core.forgerock.financial"
   AS_MTLS_FQDN: "as-mtls.sapig.bohocode-core.forgerock.financial"

--- a/core/kustomize/overlay/bohocode/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/bohocode/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/dev-aic/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/dev-aic/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/dev-cdk/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/dev-cdk/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/devops/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/devops/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/guillaumelamirand/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/guillaumelamirand/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/openig-nightly/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/openig-nightly/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/shaunharrisonfr/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/shaunharrisonfr/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:

--- a/core/kustomize/overlay/wmorrison365fr/fapi-pep-rs/kustomization.yaml
+++ b/core/kustomize/overlay/wmorrison365fr/fapi-pep-rs/kustomization.yaml
@@ -45,6 +45,21 @@ replacements:
           kind: Ingress
           name: rs-mtls
           version: v1
+  - source:
+      fieldPath: metadata.namespace
+      kind: ConfigMap
+      name: rs-sapig-deployment-config
+      version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.[nginx.ingress.kubernetes.io/auth-tls-secret]
+        options:
+          delimiter: /
+        select:
+          group: networking.k8s.io
+          kind: Ingress
+          name: rs-mtls
+          version: v1
 resources:
   - https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/_infra/kustomize/base?ref=main
 replicas:


### PR DESCRIPTION
 Missed overlay on namespace for ca crt ingress

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676